### PR TITLE
Feat reminder fix

### DIFF
--- a/src/message.ts
+++ b/src/message.ts
@@ -34,6 +34,10 @@ export default class Message {
 		return this.messageOrNote.renoteId;
 	}
 
+	public get visibility(): string {
+		return this.messageOrNote.visibility;
+	}
+
 	/**
 	 * メンション部分を除いたテキスト本文
 	 */

--- a/src/modules/reminder/index.ts
+++ b/src/modules/reminder/index.ts
@@ -59,9 +59,12 @@ export default class extends Module {
 		const separatorIndex = text.indexOf(' ') > -1 ? text.indexOf(' ') : text.indexOf('\n');
 		const thing = text.substr(separatorIndex + 1).trim();
 
-		if (thing === '' && msg.quoteId == null) {
+		if (thing === '' && msg.quoteId == null || msg.visibility === 'followers') {
 			msg.reply(serifs.reminder.invalid);
-			return true;
+			return {
+				reaction: '🆖',
+				immediate: true,
+			};
 		}
 
 		const remind = this.reminds.insertOne({

--- a/src/modules/reminder/index.ts
+++ b/src/modules/reminder/index.ts
@@ -149,7 +149,12 @@ export default class extends Module {
 					text: acct(friend.doc.user) + ' ' + serifs.reminder.notify(friend.name)
 				});
 			} catch (err) {
-				// TODO: renote対象が消されていたらリマインダー解除
+				// renote対象が消されていたらリマインダー解除
+				if (err.statusCode === 400 && err.error.error.message === 'No such renote target.') {
+					this.unsubscribeReply(remind.thing == null && remind.quoteId ? remind.quoteId : remind.id);
+					this.reminds.remove(remind);
+					return;
+				}
 				return;
 			}
 		}


### PR DESCRIPTION
# これは何
タイトルの通り。  
大きく2つの変更点があります。

## renote対象が消されていた場合にリマインダー解除を行う機能
#89 に関係しそう。  
「やった」「やめる」でリマインダー解除する場所と同じように書きました。
### 何が変わるの
リマインダーで、todoしてるノートが消されたら自動的にリマインドも解除する。

## リマインド対象のノートのvisibilityがfollowersのときにtodoを受け付けないようにした
todoをお願いしたノートのvisibilityが、followersとなっていた時に🆗とはなる。が、引用RNができなくてただ覚えているだけになっているので、それだったら最初から受け付けないようにすればいいんじゃない？となり書きました。

### 何が変わるの
- `msg.visibility`で公開範囲が取れるようになる
- リマインダーで、todoしてるノートのvisibilityが、followersだったら受け付けなくなる
- 受け付けられなかったときにNGのリアクションを返すようになる
